### PR TITLE
Support persistent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 = mruby-curl
 
+mruby-curl is an [mruby](http://mruby.org) wrapper for
+[libcurl](https://curl.haxx.se/libcurl/).
+
+== Usage
+
+Example:
+
+```ruby
+curl = Curl.new
+
+headers = {
+  'User-Agent' => 'mruby-curl'
+}
+
+response = curl.get("http://www.ruby-lang.org/ja/", headers)
+
+puts response.body
+```
+
+mruby-curl has support for HTTP methods DELETE, GET, PATCH, POST, and PUT
+through instance methods on the Curl object and supports arbitrary HTTP
+requests using `Curl#send` with an `HTTP::Request` object from
+[mruby-http](https://github.com/mattn/mruby-http).
+
 == Threaded use
 
 By default mruby-curl does not call

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+= mruby-curl
+
+== Threaded use
+
+By default mruby-curl does not call
+[curl_global_init](https://curl.haxx.se/libcurl/c/curl_global_init.html).  If
+you are using mruby-curl in a multithreaded environment you must call it
+yourself.
+
+If threads are started from within mruby the `Curl.global_init` method will
+initialize curl with the default flags.  You must call it before starting
+threads that will use mruby-curl methods.
+
+If mruby is started from a multi-threaded program you must call
+`curl_global_init` before starting any mruby threads.
+
+See the
+[curl_global_init](https://curl.haxx.se/libcurl/c/curl_global_init.html)
+documentation for more details.
+

--- a/example/example.rb
+++ b/example/example.rb
@@ -1,3 +1,11 @@
 #!mruby
 
-puts Curl::get("http://www.ruby-lang.org/ja/", {"User-Agent"=>"curl"}).body
+curl = Curl.new
+
+headers = {
+  'User-Agent' => 'mruby-curl',
+}
+
+response = curl.get("http://www.ruby-lang.org/ja/", headers)
+
+puts response.body

--- a/example/gist.rb
+++ b/example/gist.rb
@@ -18,5 +18,5 @@ req.body = JSON::stringify({
 req.headers['Authorization'] = "token #{ARGV[0]}"
 req.headers['Content-Type'] = "application/json"
 Curl::SSL_VERIFYPEER = 0
-res = Curl::send("https://api.github.com/gists", req)
+res = Curl.new.send("https://api.github.com/gists", req)
 puts JSON::parse(res.body)['html_url']

--- a/example/google_translate.rb
+++ b/example/google_translate.rb
@@ -1,6 +1,6 @@
 #!mruby
 
 url = "http://ajax.googleapis.com/ajax/services/search/web?v=1.0&q=mruby&rsz=large"
-for result in JSON::parse(Curl::get(url).body)['responseData']['results']
+for result in JSON::parse(Curl.new.get(url).body)['responseData']['results']
 	puts "#{result['titleNoFormatting']}\n  #{result['url']}"
 end

--- a/example/twitter_stream.rb
+++ b/example/twitter_stream.rb
@@ -5,7 +5,7 @@ if ARGV.size != 2
 end
 
 Curl::SSL_VERIFYPEER = 0
-Curl::get("https://stream.twitter.com/1.1/statuses/sample.json", {"Authorization"=> "Basic #{Base64::encode(ARGV[0] + ":" + ARGV[1])}"}) do |h,b|
+Curl.new.get("https://stream.twitter.com/1.1/statuses/sample.json", {"Authorization"=> "Basic #{Base64::encode(ARGV[0] + ":" + ARGV[1])}"}) do |h,b|
   begin
     tweet = JSON::parse(b)
     puts Iconv.conv("char", "utf-8", "#{tweet['user']['screen_name']}: #{tweet['text']}") if tweet.has_key?('text')

--- a/mrblib/curl.rb
+++ b/mrblib/curl.rb
@@ -1,0 +1,25 @@
+class Curl
+  def self.delete(url, headers = nil, &block)
+    new.delete url, headers, &block
+  end
+
+  def self.get(url, headers = nil, &block)
+    new.get url, headers, &block
+  end
+
+  def self.patch(url, data, headers = nil, &block)
+    new.patch url, data, headers, &block
+  end
+
+  def self.post(url, data, headers = nil, &block)
+    new.post url, data, headers, &block
+  end
+
+  def self.put(url, data, headers = nil, &block)
+    new.put url, data, headers, &block
+  end
+
+  def self.send(url, req, headers = nil, &block)
+    new.send url, req, headers, &block
+  end
+end

--- a/mrblib/curl.rb
+++ b/mrblib/curl.rb
@@ -1,25 +1,31 @@
 class Curl
   def self.delete(url, headers = nil, &block)
-    new.delete url, headers, &block
+    @curl ||= new
+    @curl.delete url, headers, &block
   end
 
   def self.get(url, headers = nil, &block)
-    new.get url, headers, &block
+    @curl ||= new
+    @curl.get url, headers, &block
   end
 
   def self.patch(url, data, headers = nil, &block)
-    new.patch url, data, headers, &block
+    @curl ||= new
+    @curl.patch url, data, headers, &block
   end
 
   def self.post(url, data, headers = nil, &block)
-    new.post url, data, headers, &block
+    @curl ||= new
+    @curl.post url, data, headers, &block
   end
 
   def self.put(url, data, headers = nil, &block)
-    new.put url, data, headers, &block
+    @curl ||= new
+    @curl.put url, data, headers, &block
   end
 
   def self.send(url, req, headers = nil, &block)
-    new.send url, req, headers, &block
+    @curl ||= new
+    @curl.send url, req, headers, &block
   end
 end

--- a/src/mrb_curl.c
+++ b/src/mrb_curl.c
@@ -219,7 +219,7 @@ mrb_curl_delete(mrb_state *mrb, mrb_value self)
   mrb_value url = mrb_nil_value();
   mrb_value headers = mrb_nil_value();
   mrb_value b = mrb_nil_value();
-  mrb_get_args(mrb, "S|H&", &url, &headers, &b);
+  mrb_get_args(mrb, "S|H!&", &url, &headers, &b);
 
   curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
@@ -237,7 +237,7 @@ mrb_curl_get(mrb_state *mrb, mrb_value self)
   mrb_value url = mrb_nil_value();
   mrb_value headers = mrb_nil_value();
   mrb_value b = mrb_nil_value();
-  mrb_get_args(mrb, "S|H&", &url, &headers, &b);
+  mrb_get_args(mrb, "S|H!&", &url, &headers, &b);
 
   curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
@@ -254,7 +254,7 @@ mrb_curl_patch(mrb_state *mrb, mrb_value self)
   mrb_value data = mrb_nil_value();
   mrb_value headers = mrb_nil_value();
   mrb_value b = mrb_nil_value();
-  mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
+  mrb_get_args(mrb, "SS|H!&", &url, &data, &headers, &b);
 
   curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, RSTRING_PTR(data));
@@ -273,7 +273,7 @@ mrb_curl_post(mrb_state *mrb, mrb_value self)
   mrb_value data = mrb_nil_value();
   mrb_value headers = mrb_nil_value();
   mrb_value b = mrb_nil_value();
-  mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
+  mrb_get_args(mrb, "SS|H!&", &url, &data, &headers, &b);
 
   curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POST, 1);
@@ -291,7 +291,7 @@ mrb_curl_put(mrb_state *mrb, mrb_value self)
   mrb_value data = mrb_nil_value();
   mrb_value headers = mrb_nil_value();
   mrb_value b = mrb_nil_value();
-  mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
+  mrb_get_args(mrb, "SS|H!&", &url, &data, &headers, &b);
 
   curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, RSTRING_PTR(data));

--- a/src/mrb_curl.c
+++ b/src/mrb_curl.c
@@ -210,6 +210,7 @@ mrb_curl_delete(mrb_state *mrb, mrb_value self)
   mrb_value b = mrb_nil_value();
   mrb_get_args(mrb, "S|H&", &url, &headers, &b);
 
+  curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
   curl_easy_setopt(curl, CURLOPT_UPLOAD, 0);
   curl_easy_setopt(curl, CURLOPT_NOBODY, 0);
@@ -227,6 +228,7 @@ mrb_curl_get(mrb_state *mrb, mrb_value self)
   mrb_value b = mrb_nil_value();
   mrb_get_args(mrb, "S|H&", &url, &headers, &b);
 
+  curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
 
   return mrb_curl_perform(mrb, curl, url, headers, b);
@@ -243,6 +245,7 @@ mrb_curl_patch(mrb_state *mrb, mrb_value self)
   mrb_value b = mrb_nil_value();
   mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
 
+  curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, RSTRING_PTR(data));
 
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PATCH");
@@ -261,6 +264,7 @@ mrb_curl_post(mrb_state *mrb, mrb_value self)
   mrb_value b = mrb_nil_value();
   mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
 
+  curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POST, 1);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, RSTRING_PTR(data));
 
@@ -278,6 +282,7 @@ mrb_curl_put(mrb_state *mrb, mrb_value self)
   mrb_value b = mrb_nil_value();
   mrb_get_args(mrb, "SS|H&", &url, &data, &headers, &b);
 
+  curl_easy_reset(curl);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, RSTRING_PTR(data));
 
   curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");

--- a/src/mrb_curl.c
+++ b/src/mrb_curl.c
@@ -85,6 +85,17 @@ memfwrite_callback(char* ptr, size_t size, size_t nmemb, void* stream) {
 }
 
 static mrb_value
+mrb_curl_global_init(mrb_state *mrb, mrb_value self) {
+  CURLcode res = curl_global_init(CURL_GLOBAL_DEFAULT);
+
+  if (res != CURLE_OK) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "unable to initialize libcurl");
+  }
+
+  return mrb_true_value();
+}
+
+static mrb_value
 mrb_curl_init(mrb_state *mrb, mrb_value self) {
   CURL* curl;
 
@@ -387,6 +398,8 @@ mrb_mruby_curl_gem_init(mrb_state* mrb)
   mrb_define_method(mrb, _class_curl, "post",   mrb_curl_post,   MRB_ARGS_REQ(2) | MRB_ARGS_OPT(1));
   mrb_define_method(mrb, _class_curl, "put",    mrb_curl_put,    MRB_ARGS_REQ(2) | MRB_ARGS_OPT(1));
   mrb_define_method(mrb, _class_curl, "send",   mrb_curl_send,   MRB_ARGS_REQ(2));
+
+  mrb_define_class_method(mrb, _class_curl, "global_init", mrb_curl_global_init, MRB_ARGS_REQ(0));
 
   mrb_define_const(mrb, _class_curl, "SSL_VERIFYPEER", mrb_fixnum_value(1));
   mrb_gc_arena_restore(mrb, ai);


### PR DESCRIPTION
This improves the performance of mruby-curl by reusing a single curl
handle for multiple requests.  This allows curl to maintain persistent
connections across calls which eliminates delays from starting up a new
connection (TCP handshake, TLS handshake, TCP slow-start).

There is an API difference here, previously Curl was a module and now it
is an instance.  The module functions are re-implemented as class
methods to allow old examples to continue to work.