### PR TITLE
Fix handling of `Transfer-Encoding: chunked`

### DIFF
--- a/src/mrb_curl.c
+++ b/src/mrb_curl.c
@@ -184,6 +184,7 @@ mrb_curl_perform(mrb_state *mrb, CURL* curl, mrb_value url, mrb_value headers, m
   curl_easy_setopt(curl, CURLOPT_HEADERDATA, mf);
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, memfwrite);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0);
+  curl_easy_setopt(curl, CURLOPT_HTTP_TRANSFER_DECODING, 0L);
 
   mrb_curl_verifypeer(mrb, curl);
 
@@ -352,6 +353,7 @@ mrb_curl_send(mrb_state *mrb, mrb_value self)
   curl_easy_setopt(curl, CURLOPT_HEADERDATA, mf);
   curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, memfwrite);
   curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0);
+  curl_easy_setopt(curl, CURLOPT_HTTP_TRANSFER_DECODING, 0L);
 
   mrb_curl_verifypeer(mrb, curl);
 


### PR DESCRIPTION
`libcurl` was doing the decoding, but leaving the `Transfer-Encoding: chunked` header in place.  The lack of chunk sizes in the body was confusing the HTTP parser, resulting in an `HPE_INVALID_CHUNK_SIZE` error.

This PR disables transfer decoding in `libcurl`, instead leaving it up to the HTTP parser in `mruby-http`.