### PR TITLE
Support choice beween http 1.0 & 1.1, default to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ through instance methods on the Curl object and supports arbitrary HTTP
 requests using `Curl#send` with an `HTTP::Request` object from
 [mruby-http](https://github.com/mattn/mruby-http).
 
+
+=== Use HTTP 1.0 instead of 1.1
+
+```ruby
+curl = Curl.new
+curl.HTTP_VERSION = Curl::HTTP_1_0
+response = curl.get("http://www.ruby-lang.org/ja/")
+```
+
 == Threaded use
 
 By default mruby-curl does not call

--- a/src/mrb_curl.c
+++ b/src/mrb_curl.c
@@ -145,6 +145,7 @@ mrb_curl_headers(mrb_state *mrb, CURL* curl, mrb_value headers) {
 static void
 mrb_curl_set_options(mrb_state *mrb, CURL *curl) {
   int ssl_verifypeer;
+  mrb_value http_version;
   mrb_value mv_cainfo = mrb_nil_value();
   struct RClass* _class_curl;
 
@@ -159,6 +160,8 @@ mrb_curl_set_options(mrb_state *mrb, CURL *curl) {
   if (!mrb_nil_p(mv_cainfo)) {
     curl_easy_setopt(curl, CURLOPT_CAINFO, RSTRING_PTR(mv_cainfo));
   }
+  http_version = mrb_const_get(mrb, mrb_obj_value(_class_curl), mrb_intern_cstr(mrb, "HTTP_VERSION"));
+  curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, mrb_int(mrb, http_version));
 }
 
 static mrb_value
@@ -412,6 +415,9 @@ mrb_mruby_curl_gem_init(mrb_state* mrb)
 
   mrb_define_const(mrb, _class_curl, "SSL_VERIFYPEER", mrb_fixnum_value(1));
   mrb_define_const(mrb, _class_curl, "CAINFO", mrb_nil_value());
+  mrb_define_const(mrb, _class_curl, "HTTP_VERSION", mrb_fixnum_value(CURL_HTTP_VERSION_1_1));
+  mrb_define_const(mrb, _class_curl, "HTTP_1_0", mrb_fixnum_value(CURL_HTTP_VERSION_1_0));
+  mrb_define_const(mrb, _class_curl, "HTTP_1_1", mrb_fixnum_value(CURL_HTTP_VERSION_1_1));
 
   mrb_gc_arena_restore(mrb, ai);
 }


### PR DESCRIPTION
# Purpose

Add ability to choose between HTTP 1.0 & 1.1

# Change

Add configuring option `Curl::HTTP_VERSION`, defaults to 1.1
Add configuration const `Curl::HTTP_1_0` & `Curl::HTTP_1_1`